### PR TITLE
Fix android-7.1 manifest

### DIFF
--- a/extras.xml
+++ b/extras.xml
@@ -18,6 +18,8 @@
         <linkfile src="pb_build.sh" dest="vendor/pb/pb_build.sh" />
     </project>
 
+    <project path="external/python3" name="android_external_python3" remote="TeamWin" revision="android-9.0"/>
+
     <!-- Include forked external unzip repo from CyanogenMod for toolbox/toybox support -->
     <project path="external/unzip" name="android_external_unzip" remote="TeamWin" revision="cm-14.1" />
 

--- a/extras.xml
+++ b/extras.xml
@@ -3,12 +3,27 @@
     <remote name="PitchBlackRecoveryProject"
             fetch="https://github.com/PitchBlackRecoveryProject"/>
 
+    <remote name="TeamWin"
+            fetch="https://github.com/TeamWin"
+            review="https://gerrit.twrp.me" />
+
+    <remote name="LineageOS"
+            fetch="https://github.com/LineageOS"
+            review="https://review.lineageos.org" />
+
     <!-- TWRP lives in omnirom android-9.0 (not AOSP!) -->
     <project path="bootable/recovery" name="android_bootable_recovery" remote="PitchBlackRecoveryProject" revision="android-9.0"/>
     <project path="vendor/pb" name="vendor_pb" remote="PitchBlackRecoveryProject" revision="pb" />
     <project path="vendor/utils" name="vendor_utils" remote="PitchBlackRecoveryProject" revision="pb">
         <linkfile src="pb_build.sh" dest="vendor/pb/pb_build.sh" />
     </project>
+
+    <!-- Include forked external unzip repo from CyanogenMod for toolbox/toybox support -->
+    <project path="external/unzip" name="android_external_unzip" remote="TeamWin" revision="cm-14.1" />
+
+    <!-- Include external LineageOS repos for nano -->
+    <project name="android_external_nano" path="external/nano" remote="LineageOS" revision="cm-14.1" />
+    <project name="android_external_libncurses" path="external/libncurses" remote="LineageOS" revision="cm-14.1" />
 
     <!-- Magiskboot -->
     <project path="external/magisk-prebuilt" name="external_magisk-prebuilt" remote="PitchBlackRecoveryProject" revision="master" />

--- a/extras.xml
+++ b/extras.xml
@@ -21,7 +21,8 @@
     <!-- Include forked external unzip repo from CyanogenMod for toolbox/toybox support -->
     <project path="external/unzip" name="android_external_unzip" remote="TeamWin" revision="cm-14.1" />
 
-    <!-- Include external LineageOS repos for nano -->
+    <!-- Include external LineageOS repos for bash & nano -->
+    <project name="android_external_bash" path="external/bash" remote="LineageOS" revision="cm-14.1" />
     <project name="android_external_nano" path="external/nano" remote="LineageOS" revision="cm-14.1" />
     <project name="android_external_libncurses" path="external/libncurses" remote="LineageOS" revision="cm-14.1" />
 

--- a/remove-minimal.xml
+++ b/remove-minimal.xml
@@ -246,7 +246,6 @@
   <remove-project name="platform/external/okhttp" />
   <remove-project name="platform/external/opencv" />
   <remove-project name="platform/external/openfst" />
-  <remove-project name="platform/external/openssh" />
   <remove-project name="platform/external/owasp/sanitizer" />
   <remove-project name="platform/external/parameter-framework" />
   <remove-project name="platform/external/pdfium" />


### PR DESCRIPTION
Because of non-existing bash/nano repos, kati fails to generate ninja files with unmet dependencies error.
After adapting commits from minimal omni manifest from TWRP 7.1, it builds and works normally for me.

Commit with python3 isn't really needed, because its not even being included in any ways for 7.1 for now.