### PR TITLE
Fixing sync error on android 10 branch

### DIFF
--- a/omni-aosp.xml
+++ b/omni-aosp.xml
@@ -42,7 +42,7 @@
   <project path="external/toybox" name="android_external_toybox" remote="omnirom" revision="android-10" />
 
   <project path="frameworks/av" name="android_frameworks_av" remote="omnirom" revision="android-10" />
-  <project path="frameworks/base" name="android_frameworks_base" remote="omnirom" revision="android-10" />
+  <project path="frameworks/base" name="android_frameworks_base_old" remote="omnirom" revision="android-10" />
   <project path="frameworks/native" name="android_frameworks_native" remote="omnirom" revision="android-10" />
   <project path="frameworks/opt/chips" name="android_frameworks_opt_chips" remote="omnirom" revision="android-10" />
   <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="omnirom" revision="android-10" />


### PR DESCRIPTION
Omni rom has moved the older versions of android to different repository.